### PR TITLE
영어 표현 다듬음

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
   </div>
   <p class="h6 font-weight-light text-white text-center">
     OpenPipeline.IO is <a href="https://lazypic.org" class="text-white"><strong>Lazypic</strong></a> pipeline toolset donwload site.<br>
-    You can use the Lazypic content creation pipeline toolset. anytime, anywhere in the world<br>
-    Just download and run.
+    You can use Content Creation Pipeline Toolset down below, made by Lazypic. Anytime, anywhere in the world,<br>
+    just download and run.
   </p>
 </div>
 


### PR DESCRIPTION
openpipeline 소개글에 있는 영어를 좀 다듬었어요.
- content creation pipeline toolset의 각 단어를 대문자로 시작하게 바꿨어요. 
    - 다 소문자니까 잘 안 읽혀서요.
- content creation pipeline toolset 앞에 있던 lazypic은 뒤로 뺐습니다. 
    - '레이지픽의 Content Creation Pipeline Toolset'을 말하고 싶은 거 같아서, CCPT는 앞에 두고 뒤에서 made by Lazypic으로 설명해줬어요.
    - lazypic에서 만들었다는 의미를 더 명확히 할 수 있고,
    - 문장 앞 쪽의 가독성도 더 좋아져서요.
- down below를 추가해줬어요.
    - '아래에 있는'이라는 뜻이에요
    - 소개글을 읽었을 때, 아래에 소프트웨어들이 있다는 걸 알려주려고 추가했어요.
- `Any time ~ run.`까지가 한 문장인 거 같아서, 대문자를 고쳤어요.
    - 문장의 시작은 대문자니까 `anytime` &rarr; `Anytime`
    - `Just`는 문장의 시작이 아니니까 `just`로